### PR TITLE
Bugfix: Deploy failing due to pnpm, switch to npm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,20 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          version: 10
-          run_install: false
-
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: "pnpm"
+          cache: "npm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: npm ci
 
       - name: Setup Pages
         id: setup_pages
@@ -53,13 +47,13 @@ jobs:
           path: |
             .next/cache
           # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Build with Next.js
-        run: pnpm run build
+        run: npm run build
         env:
           PAGES_BASE_PATH: ${{ steps.setup_pages.outputs.base_path }}
 


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` by switching the package manager from pnpm to npm. The main changes involve removing pnpm-specific steps and configuration, and replacing them with their npm equivalents.

**Package manager migration:**

* Removed the installation and setup steps for `pnpm`, and replaced all usage of `pnpm` commands (`pnpm install`, `pnpm run build`) with their npm equivalents (`npm ci`, `npm run build`).
* Updated the Node.js dependency cache configuration to use `package-lock.json` instead of `pnpm-lock.yaml`, ensuring that caching and cache keys are compatible with npm.