### PR TITLE
Add RootLayout with metadata and next-env

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,12 +14,12 @@ export const metadata: Metadata = {
 	openGraph: {
 		title: "Emir Kaan Özver - Software Developer",
 		description:
-			"Software developer across web and mobile. Turning 'what if?' into 'done.'",
+			"Software developer across web and mobile. Turning 'what if?' into 'done.', need a developer and architect for your project? Let's talk.",
 		url: "https://emirkaan.be",
 		siteName: "Emir Kaan Özver Portfolio",
 		images: [
 			{
-				url: "https://emirkaan.be/og-image.webp",
+				url: "https://emirkaan.be/emir.webp",
 				width: 1200,
 				height: 630,
 				alt: "Emir Kaan Özver Portfolio",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Add app/layout.tsx implementing the Next.js RootLayout: imports globals.css, configures JetBrains Mono via next/font, and sets site metadata (title, description, openGraph with image, icons and manifest). The layout renders children within <html lang="en"> and applies the font variable and antialiased class.